### PR TITLE
Serve video files (mp4/webm/mov/m4v/ogv/ogg) from /uploads/

### DIFF
--- a/index.php
+++ b/index.php
@@ -43,7 +43,7 @@ if (str_starts_with($url, '/uploads/')) {
         not_found($url);
         exit;
     }
-    if (!preg_match('/\.(jpe?g|png|gif|webp|svg|avif)$/i', $rel)) {
+    if (!preg_match('/\.(jpe?g|png|gif|webp|svg|avif|mp4|webm|mov|m4v|ogv|ogg)$/i', $rel)) {
         not_found($url);
         exit;
     }
@@ -61,6 +61,10 @@ if (str_starts_with($url, '/uploads/')) {
             'png'  => 'image/png',  'gif'  => 'image/gif',
             'webp' => 'image/webp', 'svg'  => 'image/svg+xml',
             'avif' => 'image/avif',
+            'mp4'  => 'video/mp4', 'm4v'  => 'video/mp4',
+            'webm' => 'video/webm',
+            'mov'  => 'video/quicktime',
+            'ogv'  => 'video/ogg',  'ogg'  => 'video/ogg',
         ];
         header('Content-Type: ' . ($mimes[$ext] ?? 'application/octet-stream'));
         header('Content-Length: ' . filesize($real));


### PR DESCRIPTION
## Summary
Extend the public-route `/uploads/` allowlist and MIME map to cover web-safe video containers. Previously image-only — any non-image extension hit `not_found()` even when the file existed on disk.

## Why
Themes routinely embed per-post screen-capture videos next to the `.md` (e.g. `/uploads/blog/<slug>/demo.mp4`). With the image-only allowlist, the browser gets a 404 with no log entry, no clue what's wrong. Found via dpblog (167 posts, 14 mp4 references — every single one 404'd).

## Mapping added
- `.mp4` / `.m4v` → `video/mp4`
- `.webm`         → `video/webm`
- `.mov`          → `video/quicktime`
- `.ogv` / `.ogg` → `video/ogg`

## Scope
- Public route only. Admin's `MediaService` uploader is still image+pdf+zip — that's a separate decision (admins typically don't paste large video files into the media library, but if you want to allow it the change is a few more entries in `MediaService::ALLOWED_EXTS`).
- Same realpath-containment + `X-Content-Type-Options: nosniff` defence as the existing image path.
- SVG's restrictive CSP remains image-only — video files don't need that sandbox.

## Test plan
- [ ] Drop a `demo.mp4` next to a post's `.md` file under `site/content/<folder>/<slug>/`.
- [ ] Reference it in the body: `<video src="/uploads/<folder>/<slug>/demo.mp4" controls></video>`.
- [ ] Reload the post; verify the browser gets `200 video/mp4` and the player renders.
- [ ] Request a path with `..` traversal or a non-allowlisted extension (`.exe`, `.php`, `.json`) → still 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)