### PR TITLE
Auto-derive post.excerpt from body when front matter omits it

### DIFF
--- a/cms/lib/Index.php
+++ b/cms/lib/Index.php
@@ -142,6 +142,11 @@ class Index
             // URL: pages are flat, everything else keeps folder prefix
             $url = $folder === 'pages' ? '/' . $slug : '/' . $relPath;
 
+            $excerpt = isset($meta['excerpt']) ? trim((string)$meta['excerpt']) : '';
+            if ($excerpt === '') {
+                $excerpt = self::deriveExcerpt($file->getPathname());
+            }
+
             $posts[$relPath] = [
                 'slug'       => $slug,
                 'folder'     => $folder,
@@ -149,6 +154,7 @@ class Index
                 'url'        => $url,
                 'title'      => $meta['title'] ?? $slug,
                 'date'       => $date,
+                'excerpt'    => $excerpt,
                 'categories' => (array)($meta['categories'] ?? []),
                 'tags'       => (array)($meta['tags'] ?? []),
                 'draft'      => !empty($meta['draft']),
@@ -178,6 +184,50 @@ class Index
         $s = strtolower(trim($s));
         $s = preg_replace('/[^a-z0-9]+/', '-', $s) ?? '';
         return trim($s, '-');
+    }
+
+    /**
+     * Derive a plain-text excerpt from the body of a Markdown file when the
+     * post's front matter doesn't include an explicit `excerpt:`. Strips
+     * front matter, common Markdown syntax, and inline HTML, then returns
+     * the first ~160 characters as a sentence-friendly snippet.
+     *
+     * Themes that read `post.excerpt` can now rely on it being non-empty
+     * for any post that has body content, without forcing every author to
+     * write a manual excerpt. Explicit front-matter `excerpt:` still wins.
+     */
+    private static function deriveExcerpt(string $absPath, int $maxLen = 160): string
+    {
+        $raw = @file_get_contents($absPath);
+        if ($raw === false) return '';
+
+        // Strip front matter (the leading --- ... --- block).
+        $body = preg_replace('/^---\r?\n.*?\r?\n---\r?\n/s', '', $raw, 1) ?? $raw;
+
+        // Drop fenced code blocks, then images, then bracketed shortcodes.
+        $body = preg_replace('/```.*?```/s', '', $body) ?? $body;
+        $body = preg_replace('/!\[[^\]]*\]\([^)]*\)/', '', $body) ?? $body;
+        $body = preg_replace('/\[[a-z][^\]]*\]/i', '', $body) ?? $body;
+
+        // Markdown link → label only: [label](url) → label.
+        $body = preg_replace('/\[([^\]]+)\]\([^)]+\)/', '$1', $body) ?? $body;
+
+        // Strip HTML tags and remaining Markdown emphasis/heading/quote markers.
+        $body = strip_tags($body);
+        $body = preg_replace('/^[#>\-*+]+\s*/m', '', $body) ?? $body;
+        $body = preg_replace('/[*_`~]+/', '', $body) ?? $body;
+
+        // Collapse whitespace.
+        $body = trim(preg_replace('/\s+/u', ' ', $body) ?? '');
+        if ($body === '') return '';
+
+        if (function_exists('mb_strlen') && mb_strlen($body) > $maxLen) {
+            $cut = mb_substr($body, 0, $maxLen);
+            $sp  = mb_strrpos($cut, ' ');
+            if ($sp !== false && $sp > $maxLen / 2) $cut = mb_substr($cut, 0, $sp);
+            return rtrim($cut, " \t\n\r.,;:") . '…';
+        }
+        return $body;
     }
 
     /**


### PR DESCRIPTION
## Summary
`Index::build()` now derives a plain-text `excerpt` for every post when no explicit `excerpt:` is present in the front matter. Themes that read `post.excerpt` get a populated value for any post with body content, instead of silently skipping.

## Why
Themes that ship excerpt rendering on archive cards (\`{% if post.excerpt %}…{% endif %}\` etc.) currently render an empty card body unless every post author remembers to write a manual \`excerpt:\` line. Auto-derivation makes \`post.excerpt\` a reliable field — the same way Hugo, Eleventy and most static-site generators handle it. Explicit front-matter \`excerpt:\` still wins.

## What it does
On index build, for each post missing a front-matter \`excerpt:\`:

1. Read the file, strip the leading \`--- ... ---\` front-matter block.
2. Strip fenced code blocks, images, bracketed shortcodes, HTML tags, and Markdown emphasis / heading / quote markers.
3. Convert \`[label](url)\` → \`label\`.
4. Collapse whitespace.
5. Clip to ~160 chars on the nearest word boundary, append an ellipsis.

## Cost
One extra \`file_get_contents()\` per \`.md\` during index rebuild, which only runs on file-mtime change. Per-request reads still come from \`site/cache/index.json\`. Effectively \"once per content edit,\" not per pageview.

## Test plan
- [ ] Existing post with explicit \`excerpt:\` → unchanged (manual value renders).
- [ ] Post with no \`excerpt:\` and a paragraph of body → archive card now shows a snippet.
- [ ] Post with only images / shortcodes / front matter → \`post.excerpt\` is \`\"\"\` (empty string), template falls back to its empty-state branch.
- [ ] Long body (e.g. 5,000 words) → snippet clips at ~160 chars, ends with \`…\`.
- [ ] Re-index after editing a \`.md\` → snippet updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)