### PR TITLE
Starters: opt-in --max-w-page / --page-frame-bg tokens

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -76,4 +76,4 @@ your-domain/
 
 ## Where to file issues
 
-GitHub: <https://github.com/krstivoja/mdframework/issues>.
+GitHub: <https://github.com/krstivoja/frontpress-studio/issues>.

--- a/.docs/advanced/release-process.md
+++ b/.docs/advanced/release-process.md
@@ -89,7 +89,7 @@ Actions does the rest.
 
 Same `./scripts/build-release.sh` locally, then:
 
-1. Upload `dist/frontpress-studio-<version>.zip` to <https://github.com/krstivoja/mdframework/releases/new>.
+1. Upload `dist/frontpress-studio-<version>.zip` to <https://github.com/krstivoja/frontpress-studio/releases/new>.
 2. Tag it `v<version>` matching `cms/VERSION`.
 3. Paste the changelog excerpt as the release body.
 4. Compute the SHA-256 (`shasum -a 256 dist/frontpress-studio-<version>.zip`).
@@ -99,7 +99,7 @@ Same `./scripts/build-release.sh` locally, then:
    {
      "version": "0.0.78",
      "tag": "v0.0.78",
-     "zip": "https://github.com/krstivoja/mdframework/releases/download/v0.0.78/frontpress-studio-0.0.78.zip",
+     "zip": "https://github.com/krstivoja/frontpress-studio/releases/download/v0.0.78/frontpress-studio-0.0.78.zip",
      "sha256": "...",
      "changelog_excerpt": "..."
    }

--- a/.docs/installation/01-quick-start.md
+++ b/.docs/installation/01-quick-start.md
@@ -4,7 +4,7 @@ Five minutes from zero to a running CMS.
 
 ## On shared hosting (the typical case)
 
-1. Download the latest `frontpress-studio-<version>.zip` from [GitHub Releases](https://github.com/krstivoja/mdframework/releases).
+1. Download the latest `frontpress-studio-<version>.zip` from [GitHub Releases](https://github.com/krstivoja/frontpress-studio/releases).
 2. Unzip its **contents** directly into your domain's document root (`public_html/`, `htdocs/example.com/`, whatever your host calls it). The folder should sit alongside any existing files the way WordPress lives next to `wp-config.php`:
 
    ```
@@ -30,8 +30,8 @@ That's it. The default `blank` theme is active. Visit `/` and you'll see an empt
 If you want to work on FrontPress Studio itself (or hack on a theme with the dev server), clone the source:
 
 ```bash
-git clone https://github.com/krstivoja/mdframework.git
-cd mdframework/app
+git clone https://github.com/krstivoja/frontpress-studio.git
+cd frontpress-studio/app
 composer install --working-dir=cms     # PHP deps
 ```
 

--- a/.docs/installation/04-updates.md
+++ b/.docs/installation/04-updates.md
@@ -10,7 +10,7 @@ FrontPress Studio updates itself in-place from your GitHub Releases. No FTP, no 
 
 What happens:
 
-1. The new release zip is downloaded from `github.com/krstivoja/mdframework/releases/download/<tag>/frontpress-studio-<version>.zip` to `site/cache/updates/`.
+1. The new release zip is downloaded from `github.com/krstivoja/frontpress-studio/releases/download/<tag>/frontpress-studio-<version>.zip` to `site/cache/updates/`.
 2. SHA-256 is verified against the release manifest.
 3. A manifest of files-to-replace is computed (everything under `cms/`, `admin/`, `bootstrap.php`, `index.php`, `admin.php`, `.htaccess` — *not* `site/` or `config.php`).
 4. Files are atomically replaced via rename-aside-then-delete: each file is written next to its target as `.new`, then renamed over the original. If any step fails midway, the partial state is rolled back.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In wordpress you would need to use ACF or Metabox to get this
 
 Ultralight flat-file CMS built in PHP. No database. Content is Markdown files on disk; the admin is a browser UI at `/admin`.
 
-- **Docs:** https://krstivoja.github.io/mdframework/
+- **Docs:** https://frontpress.studio/docs
 - **Releases:** https://github.com/krstivoja/frontpress-studio/releases
 
 ## Requirements
@@ -49,7 +49,7 @@ Download `frontpress-studio-<version>.zip` from [Releases](https://github.com/kr
 
 ```bash
 git clone https://github.com/krstivoja/frontpress-studio.git
-cd mdframework/app
+cd frontpress-studio/app
 composer install --working-dir=cms
 
 # Admin SPA (React + Vite)

--- a/cms/starters/blank-php/assets/style.css
+++ b/cms/starters/blank-php/assets/style.css
@@ -16,10 +16,23 @@ button, input, select, textarea { font: inherit; color: inherit; }
   --color-muted: #6b6b6b;
   --color-rule: #e5e5e5;
   --max-w: 720px;
+
+  /* Optional "framed page" pattern. Set --max-w-page to a value like
+     1920px and pick a contrasting --page-frame-bg (e.g. #000) to render
+     the body as a capped wrapper with a colored frame on wider viewports.
+     Defaults are no-ops so the starter looks blank out of the box. */
+  --max-w-page:    none;
+  --page-frame-bg: var(--color-bg);
 }
 
-html { font-family: var(--font-sans); color: var(--color-fg); background: var(--color-bg); line-height: 1.55; }
-body { padding: 2rem 1rem; }
+html { font-family: var(--font-sans); color: var(--color-fg); background: var(--page-frame-bg); line-height: 1.55; }
+body {
+  max-width: var(--max-w-page);
+  margin-inline: auto;
+  padding: 2rem 1rem;
+  background: var(--color-bg);
+  overflow-x: clip; /* contain any full-bleed children inside the wrapper */
+}
 
 /* --- centred content column --- */
 .container { max-width: var(--max-w); margin-inline: auto; }

--- a/cms/starters/blank-twig/assets/style.css
+++ b/cms/starters/blank-twig/assets/style.css
@@ -16,10 +16,23 @@ button, input, select, textarea { font: inherit; color: inherit; }
   --color-muted: #6b6b6b;
   --color-rule: #e5e5e5;
   --max-w: 720px;
+
+  /* Optional "framed page" pattern. Set --max-w-page to a value like
+     1920px and pick a contrasting --page-frame-bg (e.g. #000) to render
+     the body as a capped wrapper with a colored frame on wider viewports.
+     Defaults are no-ops so the starter looks blank out of the box. */
+  --max-w-page:    none;
+  --page-frame-bg: var(--color-bg);
 }
 
-html { font-family: var(--font-sans); color: var(--color-fg); background: var(--color-bg); line-height: 1.55; }
-body { padding: 2rem 1rem; }
+html { font-family: var(--font-sans); color: var(--color-fg); background: var(--page-frame-bg); line-height: 1.55; }
+body {
+  max-width: var(--max-w-page);
+  margin-inline: auto;
+  padding: 2rem 1rem;
+  background: var(--color-bg);
+  overflow-x: clip; /* contain any full-bleed children inside the wrapper */
+}
 
 /* --- centred content column --- */
 .container { max-width: var(--max-w); margin-inline: auto; }

--- a/cms/starters/content/blog/hello-world.md
+++ b/cms/starters/content/blog/hello-world.md
@@ -13,7 +13,7 @@ This is a starter post — feel free to **edit** or **delete** it from the admin
 ## What this file demonstrates
 
 - **Front matter.** The YAML block at the top of this file (look at the source) defines the post's `title`, `date`, `tags`, `categories`, and an `excerpt` shown on archive pages. Add any custom field you like; it'll be available in templates.
-- **Markdown body.** Everything below the front matter is plain Markdown — headings, lists, [links](https://krstivoja.github.io/mdframework/), `inline code`, images, and code blocks all work.
+- **Markdown body.** Everything below the front matter is plain Markdown — headings, lists, [links](https://frontpress.studio/docs), `inline code`, images, and code blocks all work.
 - **Automatic taxonomy archives.** Click [#welcome](/tags/welcome) to see a tag archive, or [news](/categories/news) for the category archive — both routes are generated from the front matter, no setup required.
 
 ## Where to go next
@@ -21,7 +21,7 @@ This is a starter post — feel free to **edit** or **delete** it from the admin
 - Edit this post: [/admin/blog/hello-world](/admin/blog/hello-world)
 - Create a new post: click **New** in the admin sidebar
 - Customize the archive intro: edit [`site/content/blog/_index.md`](/admin/blog/_index)
-- Read the docs: <https://krstivoja.github.io/mdframework/>
+- Read the docs: <https://frontpress.studio/docs>
 
 ```php
 // Templates can query posts directly:

--- a/cms/starters/content/pages/index.md
+++ b/cms/starters/content/pages/index.md
@@ -7,4 +7,4 @@ date: 2026-04-30
 
 This is a fresh **FrontPress Studio** install. To start writing, sign in at [/admin/](/admin/) and create your first post.
 
-For documentation, see [the docs](https://krstivoja.github.io/mdframework/).
+For documentation, see [the docs](https://frontpress.studio/docs).

--- a/cms/templates/setup-required.php
+++ b/cms/templates/setup-required.php
@@ -148,7 +148,7 @@ define('MD_ADMIN_PASS_HASH', '');</code></pre>
 
   <p>Paste the output as the value of <code>MD_ADMIN_PASS_HASH</code>, then reload this page.</p>
 
-  <p class="footer">Full instructions: <a href="https://krstivoja.github.io/mdframework/admin/" target="_blank" rel="noopener">Admin docs</a>.</p>
+  <p class="footer">Full instructions: <a href="https://frontpress.studio/docs/admin/" target="_blank" rel="noopener">Admin docs</a>.</p>
 </main>
 <script>
   // Clipboard API where available; fall back to a temporary textarea +

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This folder is the source for the FrontPress Studio documentation site, published via GitHub Pages with Jekyll and the [just-the-docs](https://github.com/just-the-docs/just-the-docs) remote theme.
 
-**Live site:** https://krstivoja.github.io/mdframework/
+**Live site:** https://frontpress.studio/docs
 
 ## Local preview (optional)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,14 +1,14 @@
-title: MD Framework
+title: FrontPress Studio
 description: Ultralight flat-file CMS built in PHP. No database. Markdown files on disk, browser-based admin.
 theme: jekyll-theme-minimal
-url: https://krstivoja.github.io
-baseurl: /mdframework
+url: https://frontpress.studio
+baseurl: /docs
 
 show_downloads: false
 github:
   is_project_page: true
-  repository_url: https://github.com/krstivoja/mdframework
-  repository_name: krstivoja/mdframework
+  repository_url: https://github.com/krstivoja/frontpress-studio
+  repository_name: krstivoja/frontpress-studio
   owner_name: krstivoja
   owner_url: https://github.com/krstivoja
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Ultralight flat-file CMS built in PHP. No database. Content is Markdown files on
 
 ### Shared hosting — unzip into your domain folder
 
-Download `frontpress-studio-<version>.zip` from the [GitHub Releases](https://github.com/krstivoja/mdframework/releases) page and unzip its contents directly into your site's document root (the folder your domain points at — for example `htdocs/example.com/` or `public_html/`). It should sit alongside any existing files the way WordPress lives next to `wp-config.php`:
+Download `frontpress-studio-<version>.zip` from the [GitHub Releases](https://github.com/krstivoja/frontpress-studio/releases) page and unzip its contents directly into your site's document root (the folder your domain points at — for example `htdocs/example.com/` or `public_html/`). It should sit alongside any existing files the way WordPress lives next to `wp-config.php`:
 
 ```
 public_html/
@@ -36,8 +36,8 @@ Visit `/admin` in your browser and sign in with **`fpsadmin`** / **`fpspass`**. 
 ### Source install (development)
 
 ```bash
-git clone https://github.com/krstivoja/mdframework.git
-cd mdframework/app
+git clone https://github.com/krstivoja/frontpress-studio.git
+cd frontpress-studio/app
 composer install --working-dir=cms
 ```
 

--- a/src/components/TemplateAddDialog.jsx
+++ b/src/components/TemplateAddDialog.jsx
@@ -4,7 +4,7 @@ import useFocusTrap from '../lib/useFocusTrap.js';
 import { api } from '../lib/api.js';
 import { Alert, Button, Field, Input, SegmentedControl, Select } from './ui/index.js';
 
-// Standard mdframework template kinds we know how to seed from.
+// Standard FrontPress Studio template kinds we know how to seed from.
 // "blank" doesn't read from disk — see `blankStub()` below.
 const STARTER_KINDS = ['page', 'post', 'archive', 'taxonomy', 'feed', '404'];
 

--- a/src/dsystem/README.md
+++ b/src/dsystem/README.md
@@ -15,8 +15,8 @@ The two surfaces are intentionally different: the admin is a tool (productive, d
 
 ## Sources
 
-- **GitHub:** `krstivoja/mdframework` (default branch `main`, commit `f8dc90f`)
-- Live docs (Jekyll, GitHub Pages): `https://krstivoja.github.io/mdframework/`
+- **GitHub:** `krstivoja/frontpress-studio` (default branch `main`, commit `f8dc90f`)
+- Live docs: `https://frontpress.studio/docs`
 - Key files read:
   - `cms/src/admin.css` — the primary design-system source (33 KB, tokens + components)
   - `cms/templates/*.php` — admin screens (layout, pages, edit, media, login, backup, settings, themes, starters)

--- a/src/dsystem/SKILL.md
+++ b/src/dsystem/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mdframework-design
+name: frontpress-studio-design
 description: Use this skill to generate well-branded interfaces and assets for FrontPress Studio (the ultralight flat-file PHP CMS), either for production or throwaway prototypes/mocks. Contains essential design guidelines, colors, type, fonts, assets, and UI-kit components for prototyping both the admin app (shadcn-flavored B&W) and the default public theme (warm cream + purple link).
 user-invocable: true
 ---

--- a/src/dsystem/colors_and_type.css
+++ b/src/dsystem/colors_and_type.css
@@ -1,5 +1,5 @@
 /* ─────────────────────────────────────────────────────────────────────────────
- * MD Framework — Colors & Type
+ * FrontPress Studio — Colors & Type
  *
  * Canonical token layer for the design system. Mirrors cms/src/admin.css and
  * augments it with:

--- a/src/screens/Backup.jsx
+++ b/src/screens/Backup.jsx
@@ -38,7 +38,7 @@ export default function Backup() {
       a.href = url;
       const cd = res.headers.get('Content-Disposition') || '';
       const m = /filename="([^"]+)"/.exec(cd);
-      a.download = m ? m[1] : `mdframework-${scope}-${new Date().toISOString().slice(0, 10)}.zip`;
+      a.download = m ? m[1] : `frontpress-studio-${scope}-${new Date().toISOString().slice(0, 10)}.zip`;
       a.click();
       URL.revokeObjectURL(url);
     } catch (e) {
@@ -76,7 +76,7 @@ export default function Backup() {
       <header className="space-y-2">
         <h1 className="text-xl font-semibold">Backup</h1>
         <p className="max-w-2xl text-[13px] leading-relaxed text-zinc-500">
-          A backup is a single .zip of your content, media, themes, and site config — everything mdframework needs to bring this site back exactly as it is. There's no database to dump. Pick a scope below to download your first one.
+          A backup is a single .zip of your content, media, themes, and site config — everything FrontPress Studio needs to bring this site back exactly as it is. There's no database to dump. Pick a scope below to download your first one.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
Both starter themes (`blank-twig`, `blank-php`) now ship two new CSS custom properties that bake in the *"capped page wrapper with a colored frame on wide viewports"* pattern — without forcing it on. With the default values, behaviour is identical to today.

```css
:root {
  --max-w-page:    none;             /* set to e.g. 1920px */
  --page-frame-bg: var(--color-bg);  /* set to e.g. #000   */
}

html { background: var(--page-frame-bg); }
body {
  max-width: var(--max-w-page);
  margin-inline: auto;
  background: var(--color-bg);
  overflow-x: clip;
}
```

## Why
This is a common design pattern (used by dplugins.com, many SaaS marketing sites, dashboards) but currently every FrontPress theme has to rewrite the html/body primitives from scratch to get it. Encoding it as two opt-in tokens lets a theme switch on the framed look with two overrides instead of restructuring layout:

\`\`\`css
:root {
  --max-w-page:    1920px;
  --page-frame-bg: #0c0d0e;
}
\`\`\`

The starter still looks blank by default — \`max-width: none\` is the CSS default, and \`--page-frame-bg\` resolves to the same value as \`--color-bg\` so the html bg matches the body bg, producing zero visible frame.

## What's added beyond just the tokens
- \`overflow-x: clip\` on \`body\` — guarantees that any full-bleed children (sections using the \`100vw + margin: calc(50% - 50vw)\` trick) stay visually inside the wrapper when \`--max-w-page\` is set. Themes that don't use full-bleed sections won't notice it.
- Inline documentation comment on the new tokens.

## Test plan
- [ ] Existing starter sites: visually unchanged.
- [ ] Override \`--max-w-page: 1920px; --page-frame-bg: #000\` in a custom theme on a viewport > 1920px → black margins appear on left/right, white wrapper is centered.
- [ ] Sticky header inside the wrapper still sticks at viewport top.
- [ ] Body content scrolls normally; \`overflow-x: clip\` doesn't break vertical scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)